### PR TITLE
README.md edited

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ this demo more realistic.
 1. First install dependencies
 
 ```bash
-pip3 install requirements.txt
+pip3 install -r requirements.txt
 ```
 
 2. Fill out the API keys in `.env`


### PR DESCRIPTION
Using pip3 install -r requirements.txt is a common practice in Python development when you want to install dependencies listed in a requirements.txt file. 